### PR TITLE
fix: typo

### DIFF
--- a/lib/algolia_elixir/resources/object.ex
+++ b/lib/algolia_elixir/resources/object.ex
@@ -13,7 +13,7 @@ defmodule AlgoliaElixir.Resources.Object do
     request_batch(index, "deleteObject", object_ids)
   end
 
-  def partil_update_object(index, object), do: partial_update_objects(index, [object])
+  def partial_update_object(index, object), do: partial_update_objects(index, [object])
 
   def partial_update_objects(index, objects) do
     request_batch(index, "partialUpdateObjectNoCreate", objects)


### PR DESCRIPTION
Arrumando um typo
Não vai quebrar nada, pois nenhum outro sistema nosso utiliza esta função.