### PR TITLE
feat: [EXPER-4972] add rules resource - search and batch save rules

### DIFF
--- a/lib/algolia_elixir/resources/rules.ex
+++ b/lib/algolia_elixir/resources/rules.ex
@@ -1,0 +1,11 @@
+defmodule AlgoliaElixir.Resources.Rules do
+  use AlgoliaElixir.Client
+
+  def search_rules(index, params \\ %{}) do
+    post("/indexes/#{index}/rules/search", params)
+  end
+
+  def batch_rules(index, rules) do
+    post("/indexes/#{index}/rules/batch", rules)
+  end
+end

--- a/test/resources/rules_test.exs
+++ b/test/resources/rules_test.exs
@@ -15,7 +15,17 @@ defmodule AlgoliaElixirTest.Resources.RulesTest do
     assert {:ok, %{status: 200, body: ^rules}} = Rules.search_rules("my_index")
   end
 
-  test "batch rules" do
+  test "search rules failure" do
+    response = %{"message" => "indexName is not valid", "status" => 400}
+
+    mock(fn %{method: :post, url: "https://test-dsn.algolia.net/1/indexes//rules/search"} ->
+      json(response)
+    end)
+
+    assert {:ok, %{status: 200, body: ^response}} = Rules.search_rules("")
+  end
+
+  test "batch rules success" do
     rules = build_list(5, :rule)
     response = %{"taskID" => 1_718_439_032_100, "updatedAt" => "2024-08-22T16:24:03.079Z"}
 
@@ -24,5 +34,18 @@ defmodule AlgoliaElixirTest.Resources.RulesTest do
     end)
 
     assert {:ok, %{status: 200, body: ^response}} = Rules.batch_rules("my_index", rules)
+  end
+
+  test "batch rules failure" do
+    response = %{
+      "message" => "Missing mandatory attribute `objectID` (in `[0]`) (near 1:4)",
+      "status" => 400
+    }
+
+    mock(fn %{method: :post, url: "https://test-dsn.algolia.net/1/indexes/my_index/rules/batch"} ->
+      json(response)
+    end)
+
+    assert {:ok, %{status: 200, body: ^response}} = Rules.batch_rules("my_index", [])
   end
 end

--- a/test/resources/rules_test.exs
+++ b/test/resources/rules_test.exs
@@ -1,0 +1,28 @@
+defmodule AlgoliaElixirTest.Resources.RulesTest do
+  use AlgoliaElixir.DataCase
+
+  alias AlgoliaElixir.Resources.Rules
+
+  import Tesla.Mock
+
+  test "search rules" do
+    rules = build(:rule_result)
+
+    mock(fn %{method: :post, url: "https://test-dsn.algolia.net/1/indexes/my_index/rules/search"} ->
+      json(rules)
+    end)
+
+    assert {:ok, %{status: 200, body: ^rules}} = Rules.search_rules("my_index")
+  end
+
+  test "batch rules" do
+    rules = build_list(5, :rule)
+    response = %{"taskID" => 1_718_439_032_100, "updatedAt" => "2024-08-22T16:24:03.079Z"}
+
+    mock(fn %{method: :post, url: "https://test-dsn.algolia.net/1/indexes/my_index/rules/batch"} ->
+      json(response)
+    end)
+
+    assert {:ok, %{status: 200, body: ^response}} = Rules.batch_rules("my_index", rules)
+  end
+end

--- a/test/resources/search_test.exs
+++ b/test/resources/search_test.exs
@@ -13,7 +13,7 @@ defmodule AlgoliaElixirTest.Resources.SearchTest do
 
     mock(fn %{method: :post, url: @url, body: body} ->
       assert body =~
-               URI.encode_query(%{"filters" => "(ages:old) AND (brand:brand1 OR brand:brand2)"})
+               "filters=%28ages%3A%22old%22%29+AND+%28brand%3A%22brand1%22+OR+brand%3A%22brand2%22%29&query=term"
 
       assert body =~ "query=term"
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -32,4 +32,41 @@ defmodule AlgoliaElixir.Factory do
       renderingContent: %{}
     }
   end
+
+  def rule_factory do
+    %{
+      "_metadata" => %{"lastUpdate" => 1_724_161_095},
+      "conditions" => [
+        %{
+          "pattern" => %{
+            "matchLevel" => "none",
+            "matchedWords" => [],
+            "value" => Faker.Commerce.product_name()
+          }
+        }
+      ],
+      "consequence" => %{
+        "filterPromotes" => true,
+        "promote" => [
+          %{
+            "objectIDs" => ["#{Faker.Random.Elixir.random_between(100_000, 200_000)}"],
+            "position" => 1
+          }
+        ]
+      },
+      "description" => Faker.Lorem.sentence(),
+      "enabled" => true,
+      "objectID" => "qr-#{Faker.Random.Elixir.random_between(100_000, 200_000)}",
+      "tags" => ["visual-editor"]
+    }
+  end
+
+  def rule_result_factory do
+    %{
+      "hits" => build_list(3, :rule),
+      "nbHits" => 484,
+      "nbPages" => 484,
+      "page" => 0
+    }
+  end
 end


### PR DESCRIPTION
[EXPER-4972]
Adicionando o resource rules que conta com os métodos:
- `searchRules`
- `batch_rules`

[EXPER-4972]: https://petlove.atlassian.net/browse/EXPER-4972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ