### PR TITLE
refactor: passing params by object to algolia

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.12
+erlang 24.1

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AlgoliaElixir.MixProject do
   def project do
     [
       app: :algolia_elixir,
-      version: "0.1.5",
+      version: "0.1.6",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/resources/search_test.exs
+++ b/test/resources/search_test.exs
@@ -12,10 +12,8 @@ defmodule AlgoliaElixirTest.Resources.SearchTest do
     result = %{results: [build(:search_result, hits: [object])]}
 
     mock(fn %{method: :post, url: @url, body: body} ->
-      assert body =~
-               "filters=%28ages%3A%22old%22%29+AND+%28brand%3A%22brand1%22+OR+brand%3A%22brand2%22%29&query=term"
-
-      assert body =~ "query=term"
+      assert body ==
+               "{\"requests\":[{\"filters\":\"(ages:\\\"old\\\") AND (brand:\\\"brand1\\\" OR brand:\\\"brand2\\\")\",\"indexName\":\"my_index\",\"query\":\"term\"}]}"
 
       json(result)
     end)
@@ -32,10 +30,8 @@ defmodule AlgoliaElixirTest.Resources.SearchTest do
     result = %{results: [build(:search_result, hits: [object])]}
 
     mock(fn %{method: :post, url: @url, body: body} ->
-      assert body =~
-               URI.encode_query(%{"filters" => "(ages:old) AND (brand:brand1 OR brand:brand2)"})
-
-      assert body =~ "query=term"
+      assert body ==
+               "{\"requests\":[{\"filters\":\"(ages:old) AND (brand:brand1 OR brand:brand2)\",\"indexName\":\"my_index\",\"query\":\"term\"}]}"
 
       json(result)
     end)
@@ -64,8 +60,8 @@ defmodule AlgoliaElixirTest.Resources.SearchTest do
     }
 
     mock(fn %{method: :post, url: @url, body: body} ->
-      assert body =~ "query=term1"
-      assert body =~ "query=term2"
+      assert body ==
+               "{\"requests\":[{\"indexName\":\"index1\",\"query\":\"term1\"},{\"indexName\":\"index2\",\"query\":\"term2\"}]}"
 
       json(result)
     end)


### PR DESCRIPTION
O `optionalFilters` que vamos utilizar no Axolotl é um array, e a lib `URI` do elixir não consegue fazer o encoding de listas, então mudei aqui a lib pra fazer o request pra Algolia em json mesmo, agora eles aceitam esse formato 🙏 